### PR TITLE
switch from glob to os.walk based generator which does not follow links

### DIFF
--- a/thriftybuilder/build_configurations.py
+++ b/thriftybuilder/build_configurations.py
@@ -2,7 +2,6 @@ import dockerfile
 import os
 from abc import ABCMeta, abstractmethod
 from dockerfile import Command
-from glob import glob
 from os import walk
 
 from typing import Iterable, Optional, List, Set, TypeVar, Generic, Tuple
@@ -16,6 +15,13 @@ _ADD_DOCKER_COMMAND = "add"
 _RUN_DOCKER_COMMAND = "run"
 _COPY_DOCKER_COMMAND = "copy"
 
+def walk_directory(dirpath):
+    return list(walk_directory_generator(dirpath))
+
+def walk_directory_generator(dirpath):
+    for root, _, files in walk(dirpath):
+        for file in files:
+            yield(os.path.join(root, file))
 
 class InvalidBuildConfigurationError(ThriftyBuilderBaseError):
     """
@@ -103,7 +109,7 @@ class DockerBuildConfiguration(BuildConfiguration):
         for source_path in source_patterns:
             full_source_path = os.path.normpath(os.path.join(self.context, source_path))
             if os.path.isdir(full_source_path):
-                candidate_files = glob(f"{full_source_path}/**/*", recursive=True)
+                candidate_files = walk_directory(full_source_path)
             else:
                 candidate_files = [full_source_path]
 

--- a/thriftybuilder/build_configurations.py
+++ b/thriftybuilder/build_configurations.py
@@ -3,11 +3,11 @@ import os
 from abc import ABCMeta, abstractmethod
 from dockerfile import Command
 from os import walk
-
 from typing import Iterable, Optional, List, Set, TypeVar, Generic, Tuple
+
 from zgitignore import ZgitIgnore
 
-from thriftybuilder.common import ThriftyBuilderBaseError, DEFAULT_ENCODING
+from thriftybuilder.common import ThriftyBuilderBaseError, DEFAULT_ENCODING, walk_directory
 
 DOCKER_IGNORE_FILE = ".dockerignore"
 _FROM_DOCKER_COMMAND = "from"
@@ -15,13 +15,6 @@ _ADD_DOCKER_COMMAND = "add"
 _RUN_DOCKER_COMMAND = "run"
 _COPY_DOCKER_COMMAND = "copy"
 
-def walk_directory(dirpath):
-    return list(walk_directory_generator(dirpath))
-
-def walk_directory_generator(dirpath):
-    for root, _, files in walk(dirpath):
-        for file in files:
-            yield(os.path.join(root, file))
 
 class InvalidBuildConfigurationError(ThriftyBuilderBaseError):
     """
@@ -219,6 +212,7 @@ class DockerBuildConfiguration(BuildConfiguration):
                 ignored_files.add(context_file)
 
         return ignored_files
+
 
 
 class BuildConfigurationManager(Generic[BuildConfigurationType], metaclass=ABCMeta):

--- a/thriftybuilder/common.py
+++ b/thriftybuilder/common.py
@@ -1,4 +1,6 @@
+import os
 from abc import ABCMeta
+from typing import List, Iterable
 
 DEFAULT_ENCODING = "utf-8"
 
@@ -13,3 +15,13 @@ class MissingOptionalDependencyError(ThriftyBuilderBaseError):
     """
     Exception raised if option dependency is required but not installed.
     """
+
+
+def walk_directory(directory_path: str) -> List[str]:
+    return list(walk_directory_generator(directory_path))
+
+
+def walk_directory_generator(directory_path: str) -> Iterable[str]:
+    for root, directories, files in os.walk(directory_path):
+        for file in files + directories:
+            yield (os.path.join(root, file))

--- a/thriftybuilder/common.py
+++ b/thriftybuilder/common.py
@@ -23,5 +23,5 @@ def walk_directory(directory_path: str) -> List[str]:
 
 def walk_directory_generator(directory_path: str) -> Iterable[str]:
     for root, directories, files in os.walk(directory_path):
-        for file in files + directories:
-            yield (os.path.join(root, file))
+        for name in files + directories:
+            yield (os.path.join(root, name))


### PR DESCRIPTION
fixes issue in which used_files gets stuck in an infinite loop when following symlinks (which in any case should not be followed as they are copied into the container as-is and cannot reference outside the docker build context).
